### PR TITLE
Add new option `max_y_floor`

### DIFF
--- a/src/js/common/data_graphic.js
+++ b/src/js/common/data_graphic.js
@@ -44,6 +44,7 @@ MG.data_graphic = function(args) {
     y_scale_type: 'linear',
     max_x: null,
     max_y: null,
+    max_y_floor: null,
     min_x: null,
     min_y: null,                        // if set, y axis starts at an arbitrary value
     min_y_from_data: false,             // if set, y axis will start at minimum value rather than at 0

--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -79,7 +79,7 @@ function mg_bar_add_zero_line (args) {
     .attr('y1', r[0] + mg_get_plot_top(args))
     .attr('y2', r[r.length-1] + g + args.scales.Y_ingroup.rangeBand())
     .attr('stroke', 'black')
-    .attr('opacity', .2);  
+    .attr('opacity', .2);
   }
 }
 
@@ -94,7 +94,7 @@ function set_min_max_y (args) {
 
   var my = {};
   my.min = extents[0];
-  my.max = extents[1];
+  my.max = (args.max_y_floor === null) ? extents[1] : Math.max(extents[1], args.max_y_floor);
   // the default case is for the y-axis to start at 0, unless we explicitly want it
   // to start at an arbitrary number or from the data's minimum value
   if (my.min >= 0 && !args.min_y && !args.min_y_from_data) {


### PR DESCRIPTION
Allow users to set a minimum for the y-axis max value. In contrast to
`max_y`, `max_y_floor` allows the y-axis to rescale when new data is
supplied instead of locking the y-axis max to a fixed value.
`max_y_floor` is the smallest value that the y-axis max can take.
