### PR TITLE
Fix conflict of Bootstrap Tooltip/Popover v4

### DIFF
--- a/src/js/common/bootstrap_tooltip_popover.js
+++ b/src/js/common/bootstrap_tooltip_popover.js
@@ -12,6 +12,9 @@ if (mg_jquery_exists()) {
     +function ($) {
       'use strict';
 
+      if(typeof $().tooltip == 'function')
+        return true;
+
       // TOOLTIP PUBLIC CLASS DEFINITION
       // ===============================
 
@@ -526,6 +529,9 @@ if (mg_jquery_exists()) {
 
     +function ($) {
       'use strict';
+
+      if(typeof $().popover == 'function')
+        return true;
 
       // POPOVER PUBLIC CLASS DEFINITION
       // ===============================


### PR DESCRIPTION
I had a problem with this library and Bootstrap v4. Basically metrics-graphics would override the Popover and Tooltip definition brought by Bootstrap. 

This change would not override the definitions if Bootstrap has already been loaded.