### PR TITLE
Change the judgement about whether the value is set or not in scale.js (Fixes #729)

### DIFF
--- a/src/js/common/scales.js
+++ b/src/js/common/scales.js
@@ -255,12 +255,12 @@ function mg_min_max_numerical(args, scaleArgs, additional_data_arrays) {
     max_val = (max_val < 0) ? max_val + (max_val - max_val * args.inflator) * use_inflator : max_val * (use_inflator ? args.inflator : 1);
   }
 
-  min_val = args['min_' + namespace] || min_val;
-  max_val = args['max_' + namespace] || max_val;
+  min_val = args['min_' + namespace] !== null ? args['min_' + namespace] : min_val;
+  max_val = args['max_' + namespace] !== null ? args['max_' + namespace] : max_val;
   // if there's a single data point, we should custom-set the max values
   // so we're displaying some kind of range
-  if (min_val === max_val && args['min_' + namespace] === undefined &&
-      args['max_' + namespace] === undefined) {
+  if (min_val === max_val && args['min_' + namespace] === null &&
+      args['max_' + namespace] === null) {
     if (mg_is_date(min_val)) {
       max_val = new Date(MG.clone(min_val).setDate(min_val.getDate() + 1));
     } else if (typeof min_val === 'number') {


### PR DESCRIPTION
This bug(#729) is mainly a problem with the scale range of axis, so I only modified part of the code in scale.js

If these attributes are `undefined` will be replaced to `null` by `merge_with_defaults()` in the `data_graphic()` method, so these will never strictly equal `undefined`
@wlach 