### PR TITLE
use travis ci to auto deploy the examples page to gh pages (fixes #854)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,13 @@ before_script:
     - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 script: npm run test-ci
 
+before_deploy:
+  - cp dist/metricsgraphics.css examples
+  - cp -r src/js examples
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  local-dir: examples
+  on:
+    branch: master


### PR DESCRIPTION
@wlach I've tested it. Just need to generate an access token and add it to environment variables of travis as GITHUB_TOKEN