### PR TITLE
change to use 2 equals to check an attr is null or undefined

### DIFF
--- a/src/js/common/scales.js
+++ b/src/js/common/scales.js
@@ -255,12 +255,12 @@ function mg_min_max_numerical(args, scaleArgs, additional_data_arrays) {
     max_val = (max_val < 0) ? max_val + (max_val - max_val * args.inflator) * use_inflator : max_val * (use_inflator ? args.inflator : 1);
   }
 
-  min_val = args['min_' + namespace] !== null ? args['min_' + namespace] : min_val;
-  max_val = args['max_' + namespace] !== null ? args['max_' + namespace] : max_val;
+  min_val = args['min_' + namespace] != null ? args['min_' + namespace] : min_val;
+  max_val = args['max_' + namespace] != null ? args['max_' + namespace] : max_val;
   // if there's a single data point, we should custom-set the max values
   // so we're displaying some kind of range
-  if (min_val === max_val && args['min_' + namespace] === null &&
-      args['max_' + namespace] === null) {
+  if (min_val === max_val && args['min_' + namespace] == null &&
+      args['max_' + namespace] == null) {
     if (mg_is_date(min_val)) {
       max_val = new Date(MG.clone(min_val).setDate(min_val.getDate() + 1));
     } else if (typeof min_val === 'number') {


### PR DESCRIPTION
I found an error (`Error: <circle> attribute r: Expected length, "NaN".`) in https://metricsgraphics.github.io/metrics-graphics/examples.htm#experimental

The reason of it is `args.processed.min_size & args.processed.max_size` are undefined and the domain of `args.scales.SIZE` is NaN, so `args.scalefns.sizef` return NaN.

This is because in `mg_min_max_numerical` we want to use the value we calculated if user doesn't specify the max or min value. But some options which not be specified will be set to null when initial. So we should use the value we calculated if it is null or undefined. After I checked JS comparison table and refer the question in SO(https://stackoverflow.com/questions/2559318/how-to-check-for-an-undefined-or-null-variable-in-javascript) I think it is better to change this case to use 2 equals here.