### PR TITLE
Add option to set how line(s) are dashed programmatically

### DIFF
--- a/examples/charts/multilines.htm
+++ b/examples/charts/multilines.htm
@@ -1,9 +1,9 @@
-            <div class='row trunk-section'>
-                <div class='col-lg-7 text-center' id='fake_users2'></div>
-                <div class='col-lg-5'>
-                    <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
+<div class='row trunk-section'>
+    <div class='col-lg-7 text-center' id='fake_users2'></div>
+    <div class='col-lg-5'>
+        <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
 
-<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -21,19 +21,19 @@
     });
 });</code></pre>
 
-                </div>
-            </div>
-            <div class='row'>
-                <div class='col-lg-7 text-center legend'></div>
-                <div class='col-lg-5'></div>
-            </div>
+    </div>
+</div>
+<div class='row'>
+    <div class='col-lg-7 text-center legend'></div>
+    <div class='col-lg-5'></div>
+</div>
 
-            <div class='row trunk-section'>
-                <div class='col-lg-7 text-center' id='missing_is_hidden_multi'></div>
-                <div class='col-lg-5'>
-                    <div class='data-column'><a href='data/missing-is-hidden-multi.json'>data</a></div>
+<div class='row trunk-section'>
+    <div class='col-lg-7 text-center' id='missing_is_hidden_multi'></div>
+    <div class='col-lg-5'>
+        <div class='data-column'><a href='data/missing-is-hidden-multi.json'>data</a></div>
 
-<pre><code class='javascript'>d3.json('data/missing-is-hidden-multi.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/missing-is-hidden-multi.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -51,21 +51,21 @@
     });
 });</code></pre>
 
-                </div>
-            </div>
+    </div>
+</div>
 
-            <div class='row trunk-section'>
-                <div class='col-lg-7 text-center'>
-                    <div id='linked_multi1'></div>
-                    <div id='linked_multi2'></div>
-                </div>
-                <div class='col-lg-5'>
-                    <div class='data-column'>
-                        <a href='data/fake_users2.json'>data 1</a>,
-                        <a href='data/fake_users3.json'>data 2</a>
-                    </div>
+<div class='row trunk-section'>
+    <div class='col-lg-7 text-center'>
+        <div id='linked_multi1'></div>
+        <div id='linked_multi2'></div>
+    </div>
+    <div class='col-lg-5'>
+        <div class='data-column'>
+            <a href='data/fake_users2.json'>data 1</a>,
+            <a href='data/fake_users3.json'>data 2</a>
+        </div>
 
-<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -107,7 +107,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-<pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -135,7 +135,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-<pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -164,7 +164,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
+        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     };
@@ -191,12 +191,38 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'></div>
 </div>
 
-            <div class='row trunk-section'>
-                <div class='col-lg-7 text-center' id='multiline_area_select'></div>
-                <div class='col-lg-5'>
-                    <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
+<div class='row trunk-section'>
+    <div class='col-lg-7 text-center' id='custom-dashes'></div>
+    <div class='col-lg-5'>
+        <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-                    <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    };
+     MG.data_graphic({
+        title: "Custom Line Dashing",
+        description: "By passing in an array of 'stroke-dasharray' html strings, you can specify how the lines are dashed. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
+        data: [data[0], data[1], data[2]],
+        width: 600,
+        height: 200,
+        right: 40,
+        dasharrays: ['5', '10,15', false],
+        target: '#custom-dashes',
+        aggregate_rollover: true
+    });
+})
+</code></pre>
+
+    </div>
+</div>
+
+<div class='row trunk-section'>
+    <div class='col-lg-7 text-center' id='multiline_area_select'></div>
+    <div class='col-lg-5'>
+        <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
+
+        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
 
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
@@ -216,153 +242,170 @@ d3.json('data/fake_users3.json', function(data) {
     });
 });</code></pre>
 
-<script>
-MG._hooks = {};
+        <script>
+            MG._hooks = {};
 d3.json('data/fake_users2.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
 
-    MG.data_graphic({
-        title: "Multi-Line Chart",
-        description: "This line chart contains multiple lines.",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#fake_users2',
+                MG.data_graphic({
+                    title: "Multi-Line Chart",
+                    description: "This line chart contains multiple lines.",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#fake_users2',
         legend: ['Line 1','Line 2','Line 3'],
-        legend_target: '.legend'
-    });
-});
+                    legend_target: '.legend'
+                });
+            });
 
 d3.json('data/missing-is-hidden-multi.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
 
-    MG.data_graphic({
-        title: "Broken Multi-Lines",
-        description: 'Setting <i>missing_is_hidden</i> works with multiple lines too.',
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        missing_is_hidden: true,
-        target: '#missing_is_hidden_multi',
-        show_secondary_x_label: false
-    });
-});
+                MG.data_graphic({
+                    title: "Broken Multi-Lines",
+                    description: 'Setting <i>missing_is_hidden</i> works with multiple lines too.',
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    missing_is_hidden: true,
+                    target: '#missing_is_hidden_multi',
+                    show_secondary_x_label: false
+                });
+            });
 
 d3.json('data/fake_users2.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
 
-    MG.data_graphic({
-        title: "Multi-Line Linked",
-        description: "Demoing linked multi-line charts.",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#linked_multi1',
-        linked: true
-    });
-})
-
-d3.json('data/fake_users3.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
-
-    MG.data_graphic({
-        title: "Multi-Line Linked 2",
-        description: "Demoing linked multi-line charts.",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#linked_multi2',
-        linked: true
-    });
-});
+                MG.data_graphic({
+                    title: "Multi-Line Linked",
+                    description: "Demoing linked multi-line charts.",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#linked_multi1',
+                    linked: true
+                });
+            })
 
 d3.json('data/fake_users3.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
 
-    // set this to an empty array.
-    // data[0] and data[2] both still arrays of objects.
-    data[1] = [];
-    MG.data_graphic({
-        title: "Missing Time Series Don't Get Drawn",
-        description: "We set the second array to [] instead of the loaded data. The line color order is preserved.",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#missing-multi'
-    });
-});
+                MG.data_graphic({
+                    title: "Multi-Line Linked 2",
+                    description: "Demoing linked multi-line charts.",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#linked_multi2',
+                    linked: true
+                });
+            });
 
 d3.json('data/fake_users3.json', function(data) {
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
-    }
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
+
+                // set this to an empty array.
+                // data[0] and data[2] both still arrays of objects.
+                data[1] = [];
+                MG.data_graphic({
+                    title: "Missing Time Series Don't Get Drawn",
+                    description: "We set the second array to [] instead of the loaded data. The line color order is preserved.",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#missing-multi'
+                });
+            });
+
+d3.json('data/fake_users3.json', function(data) {
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                }
     data[1][data[1].length-1].value = 50000000;
     data[2][data[2].length-1] = MG.clone(data[1][data[1].length-1]);
     data[2][data[2].length-1].value += 10000000;
 
 
-    MG.data_graphic({
-        title: "Labeling Lines",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        legend: ['US', 'CA', 'DE'],
-        target: '#multi-labelled'
-    });
-});
+                MG.data_graphic({
+                    title: "Labeling Lines",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    legend: ['US', 'CA', 'DE'],
+                    target: '#multi-labelled'
+                });
+            });
 
 d3.json('data/fake_users2.json', function(data){
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
     };
-    MG.data_graphic({
-        title: "Custom Line Coloring",
-        description: "By passing in an array of hex / rgb / rgba / html strings, you can specify the colors of the lines. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
-        data: [data[0], data[1], data[2]],
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#custom-colors',
-        legend: ['Team A','Team B','Team C'],
-        legend_target: 'div#custom-color-key',
-        colors: ['blue', 'rgb(255,100,43)', '#CCCCFF'],
-        aggregate_rollover: true
-    });
-});
+                MG.data_graphic({
+                    title: "Custom Line Coloring",
+                    description: "By passing in an array of hex / rgb / rgba / html strings, you can specify the colors of the lines. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
+                    data: [data[0], data[1], data[2]],
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#custom-colors',
+                    legend: ['Team A','Team B','Team C'],
+                    legend_target: 'div#custom-color-key',
+                    colors: ['blue', 'rgb(255,100,43)', '#CCCCFF'],
+                    aggregate_rollover: true
+                });
+            });
+
+d3.json('data/fake_users2.json', function(data){
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
+                };
+                MG.data_graphic({
+                    title: "Custom Line Dashing",
+                    description: "By passing in an array of 'stroke-dasharray' html strings, you can specify how the lines are dashed. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
+                    data: [data[0], data[1], data[2]],
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    dasharrays: ['5', '10,15', false],
+                    target: '#custom-dashes',
+                    aggregate_rollover: true
+                });
+            });
 
 d3.json('data/fake_users3.json', function(data) {
 
-    for (var i = 0; i < data.length; i++) {
-        data[i] = MG.convert.date(data[i], 'date');
+                for (var i = 0; i < data.length; i++) {
+                    data[i] = MG.convert.date(data[i], 'date');
     };
 
-    MG.data_graphic({
-        title: "Select lines of your multi-line chart having areas",
-        description: "By passing in an array of booleans in 'area' property, you can choose which lines has an area or not.",
-        data: data,
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#multiline_area_select',
-        area: [false, true, false],
-        y_extended_ticks: true,
-        x_accessor: 'date'
-    });
-});
-</script>
+                MG.data_graphic({
+                    title: "Select lines of your multi-line chart having areas",
+                    description: "By passing in an array of booleans in 'area' property, you can choose which lines has an area or not.",
+                    data: data,
+                    width: 600,
+                    height: 200,
+                    right: 40,
+                    target: '#multiline_area_select',
+                    area: [false, true, false],
+                    y_extended_ticks: true,
+                    x_accessor: 'date'
+                });
+            });
+        </script>

--- a/examples/charts/multilines.htm
+++ b/examples/charts/multilines.htm
@@ -1,9 +1,9 @@
-<div class='row trunk-section'>
-    <div class='col-lg-7 text-center' id='fake_users2'></div>
-    <div class='col-lg-5'>
-        <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='fake_users2'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
 
-        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
+<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -21,19 +21,19 @@
     });
 });</code></pre>
 
-    </div>
-</div>
-<div class='row'>
-    <div class='col-lg-7 text-center legend'></div>
-    <div class='col-lg-5'></div>
-</div>
+                </div>
+            </div>
+            <div class='row'>
+                <div class='col-lg-7 text-center legend'></div>
+                <div class='col-lg-5'></div>
+            </div>
 
-<div class='row trunk-section'>
-    <div class='col-lg-7 text-center' id='missing_is_hidden_multi'></div>
-    <div class='col-lg-5'>
-        <div class='data-column'><a href='data/missing-is-hidden-multi.json'>data</a></div>
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='missing_is_hidden_multi'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/missing-is-hidden-multi.json'>data</a></div>
 
-        <pre><code class='javascript'>d3.json('data/missing-is-hidden-multi.json', function(data) {
+<pre><code class='javascript'>d3.json('data/missing-is-hidden-multi.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -51,21 +51,21 @@
     });
 });</code></pre>
 
-    </div>
-</div>
+                </div>
+            </div>
 
-<div class='row trunk-section'>
-    <div class='col-lg-7 text-center'>
-        <div id='linked_multi1'></div>
-        <div id='linked_multi2'></div>
-    </div>
-    <div class='col-lg-5'>
-        <div class='data-column'>
-            <a href='data/fake_users2.json'>data 1</a>,
-            <a href='data/fake_users3.json'>data 2</a>
-        </div>
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center'>
+                    <div id='linked_multi1'></div>
+                    <div id='linked_multi2'></div>
+                </div>
+                <div class='col-lg-5'>
+                    <div class='data-column'>
+                        <a href='data/fake_users2.json'>data 1</a>,
+                        <a href='data/fake_users3.json'>data 2</a>
+                    </div>
 
-        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
+<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -107,7 +107,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+<pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -135,7 +135,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+<pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     }
@@ -164,7 +164,7 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-5'>
         <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
+<pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     };
@@ -190,13 +190,12 @@ d3.json('data/fake_users3.json', function(data) {
     <div class='col-lg-7 text-center legend' id='custom-color-key'></div>
     <div class='col-lg-5'></div>
 </div>
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='custom-dashes'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
 
-<div class='row trunk-section'>
-    <div class='col-lg-7 text-center' id='custom-dashes'></div>
-    <div class='col-lg-5'>
-        <div class='data-column'><a href='data/fake_users3.json'>data</a></div>
-
-        <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
+                    <pre><code class='javascript'>d3.json('data/fake_users2.json', function(data){
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
     };
@@ -216,13 +215,12 @@ d3.json('data/fake_users3.json', function(data) {
 
     </div>
 </div>
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='multiline_area_select'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
 
-<div class='row trunk-section'>
-    <div class='col-lg-7 text-center' id='multiline_area_select'></div>
-    <div class='col-lg-5'>
-        <div class='data-column'><a href='data/fake_users2.json'>data</a></div>
-
-        <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
+                    <pre><code class='javascript'>d3.json('data/fake_users3.json', function(data) {
 
     for (var i = 0; i < data.length; i++) {
         data[i] = MG.convert.date(data[i], 'date');
@@ -242,170 +240,170 @@ d3.json('data/fake_users3.json', function(data) {
     });
 });</code></pre>
 
-        <script>
-            MG._hooks = {};
+<script>
+MG._hooks = {};
 d3.json('data/fake_users2.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
 
-                MG.data_graphic({
-                    title: "Multi-Line Chart",
-                    description: "This line chart contains multiple lines.",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#fake_users2',
+    MG.data_graphic({
+        title: "Multi-Line Chart",
+        description: "This line chart contains multiple lines.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#fake_users2',
         legend: ['Line 1','Line 2','Line 3'],
-                    legend_target: '.legend'
-                });
-            });
+        legend_target: '.legend'
+    });
+});
 
 d3.json('data/missing-is-hidden-multi.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
 
-                MG.data_graphic({
-                    title: "Broken Multi-Lines",
-                    description: 'Setting <i>missing_is_hidden</i> works with multiple lines too.',
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    missing_is_hidden: true,
-                    target: '#missing_is_hidden_multi',
-                    show_secondary_x_label: false
-                });
-            });
+    MG.data_graphic({
+        title: "Broken Multi-Lines",
+        description: 'Setting <i>missing_is_hidden</i> works with multiple lines too.',
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        missing_is_hidden: true,
+        target: '#missing_is_hidden_multi',
+        show_secondary_x_label: false
+    });
+});
 
 d3.json('data/fake_users2.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
 
-                MG.data_graphic({
-                    title: "Multi-Line Linked",
-                    description: "Demoing linked multi-line charts.",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#linked_multi1',
-                    linked: true
-                });
-            })
-
-d3.json('data/fake_users3.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
-
-                MG.data_graphic({
-                    title: "Multi-Line Linked 2",
-                    description: "Demoing linked multi-line charts.",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#linked_multi2',
-                    linked: true
-                });
-            });
+    MG.data_graphic({
+        title: "Multi-Line Linked",
+        description: "Demoing linked multi-line charts.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#linked_multi1',
+        linked: true
+    });
+})
 
 d3.json('data/fake_users3.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
 
-                // set this to an empty array.
-                // data[0] and data[2] both still arrays of objects.
-                data[1] = [];
-                MG.data_graphic({
-                    title: "Missing Time Series Don't Get Drawn",
-                    description: "We set the second array to [] instead of the loaded data. The line color order is preserved.",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#missing-multi'
-                });
-            });
+    MG.data_graphic({
+        title: "Multi-Line Linked 2",
+        description: "Demoing linked multi-line charts.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#linked_multi2',
+        linked: true
+    });
+});
 
 d3.json('data/fake_users3.json', function(data) {
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                }
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
+
+    // set this to an empty array.
+    // data[0] and data[2] both still arrays of objects.
+    data[1] = [];
+    MG.data_graphic({
+        title: "Missing Time Series Don't Get Drawn",
+        description: "We set the second array to [] instead of the loaded data. The line color order is preserved.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#missing-multi'
+    });
+});
+
+d3.json('data/fake_users3.json', function(data) {
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
     data[1][data[1].length-1].value = 50000000;
     data[2][data[2].length-1] = MG.clone(data[1][data[1].length-1]);
     data[2][data[2].length-1].value += 10000000;
 
 
-                MG.data_graphic({
-                    title: "Labeling Lines",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    legend: ['US', 'CA', 'DE'],
-                    target: '#multi-labelled'
-                });
-            });
+    MG.data_graphic({
+        title: "Labeling Lines",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        legend: ['US', 'CA', 'DE'],
+        target: '#multi-labelled'
+    });
+});
 
 d3.json('data/fake_users2.json', function(data){
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
     };
-                MG.data_graphic({
-                    title: "Custom Line Coloring",
-                    description: "By passing in an array of hex / rgb / rgba / html strings, you can specify the colors of the lines. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
-                    data: [data[0], data[1], data[2]],
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#custom-colors',
-                    legend: ['Team A','Team B','Team C'],
-                    legend_target: 'div#custom-color-key',
-                    colors: ['blue', 'rgb(255,100,43)', '#CCCCFF'],
-                    aggregate_rollover: true
-                });
-            });
+    MG.data_graphic({
+        title: "Custom Line Coloring",
+        description: "By passing in an array of hex / rgb / rgba / html strings, you can specify the colors of the lines. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
+        data: [data[0], data[1], data[2]],
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#custom-colors',
+        legend: ['Team A','Team B','Team C'],
+        legend_target: 'div#custom-color-key',
+        colors: ['blue', 'rgb(255,100,43)', '#CCCCFF'],
+        aggregate_rollover: true
+    });
+});
 
 d3.json('data/fake_users2.json', function(data){
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
-                };
-                MG.data_graphic({
-                    title: "Custom Line Dashing",
-                    description: "By passing in an array of 'stroke-dasharray' html strings, you can specify how the lines are dashed. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
-                    data: [data[0], data[1], data[2]],
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    dasharrays: ['5', '10,15', false],
-                    target: '#custom-dashes',
-                    aggregate_rollover: true
-                });
-            });
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    };
+    MG.data_graphic({
+        title: "Custom Line Dashing",
+        description: "By passing in an array of 'stroke-dasharray' html strings, you can specify how the lines are dashed. NOTE: this feature may have an API change before it is fully in Metrics Graphics. Use at your own risk.",
+        data: [data[0], data[1], data[2]],
+        width: 600,
+        height: 200,
+        right: 40,
+        dasharrays: ['5', '10,15', false],
+        target: '#custom-dashes',
+        aggregate_rollover: true
+    });
+});
 
 d3.json('data/fake_users3.json', function(data) {
 
-                for (var i = 0; i < data.length; i++) {
-                    data[i] = MG.convert.date(data[i], 'date');
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
     };
 
-                MG.data_graphic({
-                    title: "Select lines of your multi-line chart having areas",
-                    description: "By passing in an array of booleans in 'area' property, you can choose which lines has an area or not.",
-                    data: data,
-                    width: 600,
-                    height: 200,
-                    right: 40,
-                    target: '#multiline_area_select',
-                    area: [false, true, false],
-                    y_extended_ticks: true,
-                    x_accessor: 'date'
-                });
-            });
-        </script>
+    MG.data_graphic({
+        title: "Select lines of your multi-line chart having areas",
+        description: "By passing in an array of booleans in 'area' property, you can choose which lines has an area or not.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#multiline_area_select',
+        area: [false, true, false],
+        y_extended_ticks: true,
+        x_accessor: 'date'
+    });
+});
+</script>

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -200,7 +200,6 @@
 
       mg_color_line(args, this_path, which_line, line_id);
       mg_dashes_line(args, this_path, which_line, line_id);
-
       mg_add_line_element(args, plot, this_path, which_line);
     }
   }

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -153,6 +153,20 @@
     }
   }
 
+  function mg_dashes_line({dasharrays}, this_path, which_line, line_id) {
+    if (dasharrays) {
+      // for now, if args.dasharrays is not an array, then keep moving as if nothing happened.
+      // if args.dasharrays is not long enough, default to the usual line_id.
+      if (dasharrays.constructor === Array) {
+        if (dasharrays[which_line]) {
+          this_path.attr('stroke-dasharray', dasharrays[which_line]);
+        }
+      } else if (dasharrays.constructor === String) {
+        this_path.attr('stroke-dasharray', dasharrays);
+      }
+    }
+  }
+
   function mg_add_line_element({animate_on_load, data, y_accessor, target}, plot, this_path, which_line) {
     if (animate_on_load) {
       plot.data_median = d3.median(data[which_line], d => d[y_accessor]);
@@ -185,6 +199,8 @@
         .attr('class', `mg-main-line mg-line${line_id}`);
 
       mg_color_line(args, this_path, which_line, line_id);
+      mg_dashes_line(args, this_path, which_line, line_id);
+
       mg_add_line_element(args, plot, this_path, which_line);
     }
   }

--- a/src/js/common/data_graphic.js
+++ b/src/js/common/data_graphic.js
@@ -79,6 +79,7 @@ MG.options = { // <name>: [<defaultValue>, <availableType>]
   chart_type: ['line', ['line', 'histogram', 'point', 'bar', 'missing-data']], // '{line, histogram, point, bar, missing-data}'],
   color: [null, ['string', 'string[]']],
   colors: [null, ['string', 'string[]']],
+  dasharrays: [null, ['string', 'string[]']], // determines whether to create lines with dasharray css property
   custom_line_color_map: [[], 'number[]'], // maps an arbitrary set of lines to colors
   decimals: [2, 'number'], // the number of decimals to show in a rollover
   error: ['', 'string'], // does the graphic have an error that we want to communicate to users


### PR DESCRIPTION
In the same way that the "colors" array attribute, this PR allows to set programmatically how lines are dashed using **stroke-dasharray** css property.

This PR includes **code + documentation**. Here the result:

![image](https://user-images.githubusercontent.com/151973/46570677-4b2fb680-c968-11e8-8ee1-cefe57bb8696.png)

Why this PR? Like my previous PRs, the need comes from my sport app [Elevate (formerly stravistix)](https://thomaschampagne.github.io/elevate/). 

The app integrates a feature called "Year progressions" where an athlete can track his progress over the year and compare with previous years (e.g. distance). 

**The need is:** Allowing athlete to set a **distance target dashed line** (e.g. 4500km) 
to make sure that he follows this line as closely as possible throughout the year to fulfill his objective. Something like that:

![untitled](https://user-images.githubusercontent.com/151973/46570823-b4b0c480-c96a-11e8-83e1-35ddc32c8e06.png)

This cannot be covered by overriding **.mg-lineX-color** classes because number of lines to handle is "dynamic" (=unknown number of years at runtime)

Thanks !




