### PR TITLE
Serve GitHub star over HTTPS

### DIFF
--- a/examples/index.htm
+++ b/examples/index.htm
@@ -35,7 +35,7 @@
     <div class='container'>
         <div id='content-body'>
             <img src='images/logo.svg' id='logo' class='svg' />
-            <iframe src="http://ghbtns.com/github-btn.html?user=mozilla&repo=metrics-graphics&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20" class='github-stars-top'></iframe>
+            <iframe src="https://ghbtns.com/github-btn.html?user=mozilla&repo=metrics-graphics&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20" class='github-stars-top'></iframe>
 
             <div id='description'>
                 <p><i>MetricsGraphics.js</i> is a library built on top of


### PR DESCRIPTION
I've updated index.html to server the GitHub star button over HTTPS as some new browsers just block insecure iframes on secure pages.

Tassu