### PR TITLE
docs: Fix simple typo, overlow -> overflow

### DIFF
--- a/dist/metricsgraphics.js
+++ b/dist/metricsgraphics.js
@@ -524,7 +524,7 @@ MG.warn_deprecation = warn_deprecation;
 
 /**
   Truncate a string to fit within an SVG text node
-  CSS text-overlow doesn't apply to SVG <= 1.2
+  CSS text-overflow doesn't apply to SVG <= 1.2
 
   @author Dan de Havilland (github.com/dandehavilland)
   @date 2014-12-02

--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -549,7 +549,7 @@ MG.warn_deprecation = warn_deprecation;
 
 /**
   Truncate a string to fit within an SVG text node
-  CSS text-overlow doesn't apply to SVG <= 1.2
+  CSS text-overflow doesn't apply to SVG <= 1.2
 
   @author Dan de Havilland (github.com/dandehavilland)
   @date 2014-12-02


### PR DESCRIPTION
There is a small typo in dist/metricsgraphics.js, src/js/misc/utility.js.

Should read `overflow` rather than `overlow`.

